### PR TITLE
Feat/hng 2145 add SKU code

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -34,6 +34,7 @@ const Page = () => {
     buying_price: number;
     quantity: number;
     currency_code: string;
+    sku_code: string;
     buying_date?: string;
     product_id?: string;
     status?: string;
@@ -149,6 +150,7 @@ const Page = () => {
           onCancel={() => setIsDeleteModalOpen(false)}
           onDelete={handleDeleteItem}
           selectedItem={selectedItem || undefined}
+          includeSkuCode
         />
         <div className="lg:border px-4 py-2 lg:shadow-md rounded-lg lg:flex items-center justify-between mx-auto">
           <div className="flex items-center gap-6">
@@ -208,6 +210,7 @@ const Page = () => {
                     setStockItems((prev) => [newItem, ...prev]); // Inserts new items at the top
 
                     closeModal();
+                    includeSkuCode
                   }}
                 />
               </div>
@@ -223,6 +226,9 @@ const Page = () => {
                         ITEM NAME
                       </span>
                     </li>
+                    <li className="w-1/3 lg:w-1/6 lg:border-r-2 border-[#DEDEDE] text-center py-4 hover:cursor-pointer">
+    <span className="font-semibold text-black text-sm">SKU CODE</span> 
+  </li>
                     <li className="w-1/3 lg:w-1/6 lg:border-r-2 border-[#DEDEDE] text-center py-4 hover:cursor-pointer">
                       <span className="font-semibold text-black text-sm">
                         PRICE
@@ -266,6 +272,7 @@ const Page = () => {
                           setStockItems((prev) => [newItem, ...prev]);
                           closeModal();
                         }}
+                        
                       />
                     </div>
                   </div>
@@ -277,6 +284,9 @@ const Page = () => {
                   <TableRow className="h-[50px]">
                     <TableHead className="px-4 py-2 w-2/7 text-left border-b border-r">
                       ITEM NAME
+                    </TableHead>
+                    <TableHead className="px-4 py-2 w-2/7 text-left border-b border-r">
+                      SKU CODE
                     </TableHead>
                     <TableHead className="px-4 py-2 w-1/7 text-center border-b border-r">
                       PRICE
@@ -298,6 +308,9 @@ const Page = () => {
                       <TableRow key={index} className="h-[50px]">
                         <TableCell className="px-4 py-3 text-left border-r">
                           {item ? item.name : ""}
+                        </TableCell>
+                        <TableCell className="px-4 py-3 text-left border-r">
+                          {item ? item.sku_code : ""}
                         </TableCell>
                         <TableCell className="px-4 py-3 text-center border-r">
                           {item

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -34,7 +34,6 @@ const Page = () => {
     buying_price: number;
     quantity: number;
     currency_code: string;
-    sku_code: string;
     buying_date?: string;
     product_id?: string;
     status?: string;
@@ -150,7 +149,6 @@ const Page = () => {
           onCancel={() => setIsDeleteModalOpen(false)}
           onDelete={handleDeleteItem}
           selectedItem={selectedItem || undefined}
-          includeSkuCode
         />
         <div className="lg:border px-4 py-2 lg:shadow-md rounded-lg lg:flex items-center justify-between mx-auto">
           <div className="flex items-center gap-6">
@@ -210,8 +208,8 @@ const Page = () => {
                     setStockItems((prev) => [newItem, ...prev]); // Inserts new items at the top
 
                     closeModal();
-                    includeSkuCode
                   }}
+                  
                 />
               </div>
             )}
@@ -285,7 +283,7 @@ const Page = () => {
                     <TableHead className="px-4 py-2 w-2/7 text-left border-b border-r">
                       ITEM NAME
                     </TableHead>
-                    <TableHead className="px-4 py-2 w-2/7 text-left border-b border-r">
+                    <TableHead className="px-4 py-2 w-1/7 text-center border-b border-r">
                       SKU CODE
                     </TableHead>
                     <TableHead className="px-4 py-2 w-1/7 text-center border-b border-r">
@@ -309,8 +307,8 @@ const Page = () => {
                         <TableCell className="px-4 py-3 text-left border-r">
                           {item ? item.name : ""}
                         </TableCell>
-                        <TableCell className="px-4 py-3 text-left border-r">
-                          {item ? item.sku_code : ""}
+                        <TableCell className="px-4 py-3 text-center border-r">
+                          {"SKU-CODE"}
                         </TableCell>
                         <TableCell className="px-4 py-3 text-center border-r">
                           {item

--- a/components/modal/add-item.tsx
+++ b/components/modal/add-item.tsx
@@ -57,7 +57,6 @@ interface AddStockModalProps {
     buying_price: number; // Changed from price to buying_price
     quantity: number;
     currency_code: string; // Added currency_code
-    sku_code: string;
   }) => void;
 }
 
@@ -80,11 +79,7 @@ export default function AddStockModal({
     currencies[0]
   );
 
-  const generateSKU = () => {
-    const randomNumber = Math.floor(Math.random() * 1000000);
-    return `SKU-${randomNumber}`;
-  };
-
+ 
   const validateForm = () => {
     const newErrors: { [key: string]: string } = {};
 
@@ -125,7 +120,7 @@ export default function AddStockModal({
     setIsLoading(true);
 
     try {
-      const finalSkuCode = skuCode.trim() ? skuCode : generateSKU();
+      // const finalSkuCode = skuCode.trim() || null;
 
       const newStock = await AddStock(
         productName,
@@ -136,7 +131,7 @@ export default function AddStockModal({
         "160db8736a9d47989381e01a987e4413", // Hardcoded organization_id
         new Date().toISOString(),
         selectedSellingCurrency,
-        finalSkuCode
+        // finalSkuCode
       );
 
       // Call the onSave callback with the new stock item
@@ -145,8 +140,7 @@ export default function AddStockModal({
         name: newStock.name,
         buying_price: newStock.buying_price,
         quantity: newStock.quantity,
-        currency_code: newStock.currency_code,
-        sku_code: finalSkuCode,
+        currency_code: newStock.currency_code
       });
 
       // Reset the form fields
@@ -244,15 +238,15 @@ export default function AddStockModal({
                 required
               />
             </div>
-            <div className="flex gap-5 flex-1">
-              <div className="flex flex-col gap-[8px] flex-1 w-[326px] border">
+            <div className="flex  gap-5 flex-1 max-[640px]:flex-col">
+              <div className="flex flex-col gap-[12px] flex-1 ">
                 <label className="font-circular-normal text-[14px] text-[#717171] text-left">
                   SKU Code
                 </label>
                 <input
                   type="text"
                   name="sku-code"
-                  className="w-full h-[48px] md:h-[62px] rounded-[9px] p-4 outline-none  border-[#DEDEDE] placeholder:text-[#B8B8B8] text-[#2A2A2A] text-[16px] font-circular-normal bg-white"
+                  className="w-full h-[48px] md:h-[62px] rounded-[9px] p-4 outline-none border border-[#DEDEDE] placeholder:text-[#B8B8B8] text-[#2A2A2A] text-[16px] font-circular-normal"
                   placeholder="SKU Code"
                   value={skuCode}
                   onChange={(e) => {
@@ -270,7 +264,7 @@ export default function AddStockModal({
                 )}
               </div>
 
-              <div className="flex flex-col gap-[8px] flex-1 w-[326px] ">
+              <div className="flex flex-col gap-[8px] flex-1 ">
                 <label className="font-circular-normal text-[14px] text-[#717171] text-left">
                   Selling Price <span className="text-[#FF1925]">*</span>
                 </label>

--- a/components/modal/add-item.tsx
+++ b/components/modal/add-item.tsx
@@ -57,6 +57,7 @@ interface AddStockModalProps {
     buying_price: number; // Changed from price to buying_price
     quantity: number;
     currency_code: string; // Added currency_code
+    sku_code: string;
   }) => void;
 }
 
@@ -72,11 +73,17 @@ export default function AddStockModal({
   const [isLoading, setIsLoading] = useState(false);
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
   const [productName, setProductName] = useState("");
+  const [skuCode, setSkuCode] = useState("");
   const [sellingPrice, setSellingPrice] = useState("");
   const [quantity, setQuantity] = useState(0);
   const [selectedSellingCurrency, setSelectedSellingCurrency] = useState(
     currencies[0]
   );
+
+  const generateSKU = () => {
+    const randomNumber = Math.floor(Math.random() * 1000000);
+    return `SKU-${randomNumber}`;
+  };
 
   const validateForm = () => {
     const newErrors: { [key: string]: string } = {};
@@ -89,6 +96,10 @@ export default function AddStockModal({
       newErrors.sellingPrice = "Selling Price must be a number.";
 
     if (quantity === 0) newErrors.quantity = "Quantity must be greater than 0.";
+
+    if (skuCode.trim() && !/^[a-zA-Z0-9-]+$/.test(skuCode)) {
+      newErrors.skuCode = "SKU Code must be alphanumeric.";
+    }
 
     setErrors(newErrors);
 
@@ -114,6 +125,8 @@ export default function AddStockModal({
     setIsLoading(true);
 
     try {
+      const finalSkuCode = skuCode.trim() ? skuCode : generateSKU();
+
       const newStock = await AddStock(
         productName,
         parseFloat(sellingPrice),
@@ -122,7 +135,8 @@ export default function AddStockModal({
         selectedSellingCurrency.code,
         "160db8736a9d47989381e01a987e4413", // Hardcoded organization_id
         new Date().toISOString(),
-        selectedSellingCurrency
+        selectedSellingCurrency,
+        finalSkuCode
       );
 
       // Call the onSave callback with the new stock item
@@ -132,6 +146,7 @@ export default function AddStockModal({
         buying_price: newStock.buying_price,
         quantity: newStock.quantity,
         currency_code: newStock.currency_code,
+        sku_code: finalSkuCode,
       });
 
       // Reset the form fields
@@ -139,6 +154,7 @@ export default function AddStockModal({
       setSellingPrice("");
       setQuantity(0);
       setSelectedSellingCurrency(currencies[0]);
+      setSkuCode("");
 
       onClose(); // Close the modal
     } catch (error) {
@@ -228,90 +244,117 @@ export default function AddStockModal({
                 required
               />
             </div>
-            <div className="flex flex-col gap-[8px] flex-1">
-              <label className="font-circular-normal text-[14px] text-[#717171] text-left">
-                Selling Price <span className="text-[#FF1925]">*</span>
-              </label>
-              <div
-                ref={sellingPriceDivRef}
-                className="flex border gap-[8px] rounded-[9px] m-1 relative h-[48px] md:h-[62px]"
-              >
-                <div
-                  className="p-2 flex gap-[8px] items-center cursor-pointer"
-                  onClick={toggleCurrencyModal}
-                >
-                  <Image
-                    src={selectedSellingCurrency.flag}
-                    alt={`${selectedSellingCurrency.name} Flag`}
-                    className="w-5 h-5 md:w-6 md:h-6"
-                    width={20}
-                    height={20}
-                  />
-                  <span className="text-[20px] text-center text-[#595959]">
-                    {selectedSellingCurrency.symbol}
-                  </span>
-                  <FaChevronDown className="w-[10px] h-[10px] text-[#888888]" />
-                </div>
-                <div className="h-8 border border-gray self-center"></div>
-                <div className="w-full">
-                  <input
-                    type="number"
-                    name="selling-price"
-                    className="w-full h-full p-3 outline-none placeholder:text-[#B8B8B8] text-[#2A2A2A] text-base font-circular-normal"
-                    placeholder="Amount"
-                    value={sellingPrice}
-                    onChange={(e) => setSellingPrice(e.target.value)}
-                    required
-                  />
-                </div>
-
-                {isCurrencyModalOpen && (
-                  <div
-                    ref={dropdownRef}
-                    className="absolute top-full left-0 w-[298px] bg-white rounded-lg backdrop-blur-sm border shadow-lg z-10"
-                  >
-                    <div className="relative w-full p-4">
-                      <input
-                        type="text"
-                        name="item-name"
-                        className="w-full rounded-[10px] p-2 pl-[48px] outline-none placeholder:text-[#B8B8B8] text-[16px] border bg-white"
-                        placeholder="Search"
-                        value={searchQuery}
-                        onChange={(e) => setSearchQuery(e.target.value)}
-                        required
-                      />
-                      <FaSearch className="absolute left-[32px] top-1/2 transform -translate-y-1/2 text-[#B8B8B8] w-[20px] h-[20px]" />
-                    </div>
-
-                    <div className="h-[200px] overflow-y-auto custom-scrollbar px-[20px] py-3 ">
-                      {filteredCurrencies.map((currency) => (
-                        <div
-                          key={currency.code}
-                          className="flex items-center p-2 hover:bg-gray-100 w-full cursor-pointer"
-                          onClick={() => handleCurrencySelect(currency)}
-                        >
-                          <img
-                            src={currency.flag}
-                            alt={`${currency.name} Flag`}
-                            className="w-8 h-8 rounded-full object-cover mr-3"
-                          />
-                          <div>
-                            <p className="text-[14px] font-circular-normal">
-                              {currency.name} ({currency.code}){" "}
-                              <span className="ml-2">{currency.symbol}</span>
-                            </p>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
+            <div className="flex gap-5 flex-1">
+              <div className="flex flex-col gap-[8px] flex-1 w-[326px] border">
+                <label className="font-circular-normal text-[14px] text-[#717171] text-left">
+                  SKU Code
+                </label>
+                <input
+                  type="text"
+                  name="sku-code"
+                  className="w-full h-[48px] md:h-[62px] rounded-[9px] p-4 outline-none  border-[#DEDEDE] placeholder:text-[#B8B8B8] text-[#2A2A2A] text-[16px] font-circular-normal bg-white"
+                  placeholder="SKU Code"
+                  value={skuCode}
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    // Allow only alphanumeric characters and hyphens
+                    if (/^[a-zA-Z0-9-]*$/.test(value)) {
+                      setSkuCode(value);
+                    }
+                  }}
+                />
+                {errors.skuCode && (
+                  <p className="text-[#FF1925] text-sm font-circular-normal">
+                    {errors.skuCode}
+                  </p>
                 )}
               </div>
-              {errors.sellingPrice && (
-                <p className="text-[#FF1925] text-sm font-circular-normal">
-                  {errors.sellingPrice}
-                </p>
-              )}
+
+              <div className="flex flex-col gap-[8px] flex-1 w-[326px] ">
+                <label className="font-circular-normal text-[14px] text-[#717171] text-left">
+                  Selling Price <span className="text-[#FF1925]">*</span>
+                </label>
+                <div
+                  ref={sellingPriceDivRef}
+                  className="flex border gap-[8px] rounded-[9px] m-1 relative h-[48px] md:h-[62px]"
+                >
+                  <div
+                    className="p-2 flex gap-[8px] items-center cursor-pointer"
+                    onClick={toggleCurrencyModal}
+                  >
+                    <Image
+                      src={selectedSellingCurrency.flag}
+                      alt={`${selectedSellingCurrency.name} Flag`}
+                      className="w-5 h-5 md:w-6 md:h-6"
+                      width={20}
+                      height={20}
+                    />
+                    <span className="text-[20px] text-center text-[#595959]">
+                      {selectedSellingCurrency.symbol}
+                    </span>
+                    <FaChevronDown className="w-[10px] h-[10px] text-[#888888]" />
+                  </div>
+                  <div className="h-8 border border-gray self-center"></div>
+                  <div className="w-full">
+                    <input
+                      type="number"
+                      name="selling-price"
+                      className="w-full h-full p-3 outline-none placeholder:text-[#B8B8B8] text-[#2A2A2A] text-base font-circular-normal"
+                      placeholder="Amount"
+                      value={sellingPrice}
+                      onChange={(e) => setSellingPrice(e.target.value)}
+                      required
+                    />
+                  </div>
+
+                  {isCurrencyModalOpen && (
+                    <div
+                      ref={dropdownRef}
+                      className="absolute top-full left-0 w-[298px] bg-white rounded-lg backdrop-blur-sm border shadow-lg z-10"
+                    >
+                      <div className="relative w-full p-4">
+                        <input
+                          type="text"
+                          name="item-name"
+                          className="w-full rounded-[10px] p-2 pl-[48px] outline-none placeholder:text-[#B8B8B8] text-[16px] border bg-white"
+                          placeholder="Search"
+                          value={searchQuery}
+                          onChange={(e) => setSearchQuery(e.target.value)}
+                          required
+                        />
+                        <FaSearch className="absolute left-[32px] top-1/2 transform -translate-y-1/2 text-[#B8B8B8] w-[20px] h-[20px]" />
+                      </div>
+
+                      <div className="h-[200px] overflow-y-auto custom-scrollbar px-[20px] py-3 ">
+                        {filteredCurrencies.map((currency) => (
+                          <div
+                            key={currency.code}
+                            className="flex items-center p-2 hover:bg-gray-100 w-full cursor-pointer"
+                            onClick={() => handleCurrencySelect(currency)}
+                          >
+                            <img
+                              src={currency.flag}
+                              alt={`${currency.name} Flag`}
+                              className="w-8 h-8 rounded-full object-cover mr-3"
+                            />
+                            <div>
+                              <p className="text-[14px] font-circular-normal">
+                                {currency.name} ({currency.code}){" "}
+                                <span className="ml-2">{currency.symbol}</span>
+                              </p>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+                {errors.sellingPrice && (
+                  <p className="text-[#FF1925] text-sm font-circular-normal">
+                    {errors.sellingPrice}
+                  </p>
+                )}
+              </div>
             </div>
             <div className="flex flex-col gap-[8px]">
               <label className="font-circular-normal text-[14px] text-[#1B1B1B] text-left">


### PR DESCRIPTION
#### Follow this template:

## What?

I've added the SKU code input field to the add stock modal and displayed in the table on the dashboard 

## Why?

These changes allow users to include sku if they wish. It is optional

## How?

This includes an  input field built with Next.js and Tailwind CSS

## Testing?

I've tested the input and I also verified that the UI matches the Figma design.

## Screenshots (optional)

Screenshot/s of the login page.
![image](https://github.com/user-attachments/assets/b76656b7-1631-4739-a1cf-7a41f9f68b51)

![image](https://github.com/user-attachments/assets/f7ca37d4-75c5-4fb3-8be5-c4deb1226861)

![image](https://github.com/user-attachments/assets/2f629e3d-59fa-4715-a9ea-3a7b638d4378)






