### PR TITLE
feat: add Zustand store for managing organization state

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "shopdesk": "file:",
         "tailwind-merge": "^3.0.2",
         "tailwindcss-animate": "^1.0.7",
+        "zustand": "^5.0.3",
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
@@ -494,6 +495,8 @@
     "webpack": ["webpack@5.98.0", "", { "dependencies": { "@types/eslint-scope": "^3.7.7", "@types/estree": "^1.0.6", "@webassemblyjs/ast": "^1.14.1", "@webassemblyjs/wasm-edit": "^1.14.1", "@webassemblyjs/wasm-parser": "^1.14.1", "acorn": "^8.14.0", "browserslist": "^4.24.0", "chrome-trace-event": "^1.0.2", "enhanced-resolve": "^5.17.1", "es-module-lexer": "^1.2.1", "eslint-scope": "5.1.1", "events": "^3.2.0", "glob-to-regexp": "^0.4.1", "graceful-fs": "^4.2.11", "json-parse-even-better-errors": "^2.3.1", "loader-runner": "^4.2.0", "mime-types": "^2.1.27", "neo-async": "^2.6.2", "schema-utils": "^4.3.0", "tapable": "^2.1.1", "terser-webpack-plugin": "^5.3.11", "watchpack": "^2.4.1", "webpack-sources": "^3.2.3" }, "bin": { "webpack": "bin/webpack.js" } }, "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA=="],
 
     "webpack-sources": ["webpack-sources@3.2.3", "", {}, "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w=="],
+
+    "zustand": ["zustand@5.0.3", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg=="],
 
     "esrecurse/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "react-icons": "^5.5.0",
     "shopdesk": "file:",
     "tailwind-merge": "^3.0.2",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",

--- a/store/useStore.ts
+++ b/store/useStore.ts
@@ -13,3 +13,39 @@ export const useStore = create<State>((set) => ({
   setOrganizationId: (organizationId) => set({ organizationId }),
   setOrganizationName: (organizationName) => set({ organizationName }),
 }));
+
+
+/*
+Usage for Stephen
+import useStore from 'path'
+
+const {organizationId, organizationName, setOrganizationId, setOrganizationName} = useStore(); // just destructure the properties that you need.
+
+ TO SET A VALUE
+
+setOrganizationId('the_organization_id');
+or
+setOrganizationName('the_organization_name');
+
+TO USE THE STATE
+
+EXAMPLE:
+
+<p>Organization ID: {organizationId}</p>
+or 
+<p>Organization Name: {organizationName}</p>
+
+Or To send to an API route as request body
+
+const body = {
+  organizationId, // ensure you've set the organization id first
+  productId, // if available or needed
+  name: inputValueStateForName,
+} // and so on
+
+ TO SEND TO API ROUTE AS A PARAMETER
+
+ const apiUrl = `api/stocks/create?organization_id=${organizationId}`
+
+ THANK YOU!!!!!!!!!!1
+*/

--- a/store/useStore.ts
+++ b/store/useStore.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+type State = {
+  organizationId: string;
+  organizationName: string;
+  setOrganizationId: (organizationId: string) => void;
+  setOrganizationName: (organizationName: string) => void;
+};
+
+export const useStore = create<State>((set) => ({
+  organizationId: "",
+  organizationName: "",
+  setOrganizationId: (organizationId) => set({ organizationId }),
+  setOrganizationName: (organizationName) => set({ organizationName }),
+}));


### PR DESCRIPTION
- **chore: add zustand**
- **feat: initialize zustand store**
- **chore: add comments on usage guide**


# 🛠 Add Zustand Store for State Management
# 📌 Summary
- This PR introduces Zustand for managing application state, initializes a Zustand store, and includes a detailed usage guide with comments for easier integration.

#  Changes Included
## chore: add zustand
- Installed Zustand using the bun package manager.
## feat: initialize zustand store
- Created a Zustand store to manage organizationId and organizationName.
- Added state setters (setOrganizationId, setOrganizationName) for easy updates.
## chore: add comments on usage guide
- Added detailed comments explaining how to use the store:
	- Importing and accessing state.
	- Updating values.
	- Using state in API calls and URL parameters.

# Why This Is Needed
- Improves state management by providing a centralized, reusable store.
-Simplifies handling and sharing organization data across components.
